### PR TITLE
Use Docker CE repository for Debian 9 "Stretch"

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -27,7 +27,8 @@
 # [*docker_version*]
 #   This is the version of the docker runtime that you want to install.
 #   Defaults to 17.03.0.ce-1.el7.centos on RedHat
-#   Defaults to 17.03.0~ce-0~ubuntu-xenial on Debian
+#   Defaults to 17.03.0~ce-0~ubuntu-xenial on Ubuntu
+#   Defaults to 17.03.0~ce-0~debian-stretch on Debian
 #
 # [*cni_pod_cidr*]
 #   The overlay (internal) network range to use.

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -5,13 +5,24 @@ class kubernetes::params {
 $kubernetes_version = '1.10.2'
 case $::osfamily {
   'Debian' : {
-    $kubernetes_package_version = "${kubernetes_version}-00"
-    $docker_version = '17.03.0~ce-0~ubuntu-xenial'
+
+    case $::operatingsystem {
+      'Ubuntu': {
+        $kubernetes_package_version = "${kubernetes_version}-00"
+        $docker_version = '17.03.0~ce-0~ubuntu-xenial'
+      }
+      'Debian': {
+        $kubernetes_package_version = "${kubernetes_version}-00"
+        $docker_version = '17.03.0~ce-0~debian-stretch'
+      }
+      default: { notify {"The ${::operatingsystem} variant of Debian is not supported by this module":} }
+    }
   }
-  'RedHat' : {
+  'RedHat': {
     $kubernetes_package_version = $kubernetes_version
     $docker_version = '17.03.1.ce-1.el7.centos'
   }
+
   default: { notify {"The OS family ${::osfamily} is not supported by this module":} }
 }
 $container_runtime = 'docker'

--- a/manifests/repos.pp
+++ b/manifests/repos.pp
@@ -6,6 +6,7 @@ class kubernetes::repos (
 
   case $::osfamily  {
     'Debian': {
+
       apt::source { 'kubernetes':
         location => 'http://apt.kubernetes.io',
         repos    => 'main',
@@ -13,18 +14,34 @@ class kubernetes::repos (
         key      => {
           'id'     => '54A647F9048D5688D7DA2ABE6A030B21BA07F4FB',
           'source' => 'https://packages.cloud.google.com/apt/doc/apt-key.gpg',
-          },
-        }
+        },
+      }
 
-        if $container_runtime == 'docker' {
-          apt::source { 'docker':
-            location => 'https://apt.dockerproject.org/repo',
-            repos    => 'main',
-            release  => 'ubuntu-xenial',
-            key      => {
-              'id'     => '58118E89F3A912897C070ADBF76221572C52609D',
-              'source' => 'https://apt.dockerproject.org/gpg',
-          },
+      if $container_runtime == 'docker' {
+        case $::operatingsystem {
+          'Ubuntu': {
+            apt::source { 'docker':
+              location => 'https://apt.dockerproject.org/repo',
+              repos    => 'main',
+              release  => 'ubuntu-xenial',
+              key      => {
+                'id'     => '58118E89F3A912897C070ADBF76221572C52609D',
+                'source' => 'https://apt.dockerproject.org/gpg',
+              },
+            }
+          }
+          'Debian': {
+            apt::source { 'docker':
+              location => 'https://apt.dockerproject.org/repo',
+              repos    => 'main',
+              release  => 'debian-stretch',
+              key      => {
+                'id'     => '58118E89F3A912897C070ADBF76221572C52609D',
+                'source' => 'https://apt.dockerproject.org/gpg',
+              },
+            }
+          }
+          default: { notify {"The ${::operatingsystem} variant of Debian is not supported by this module":} }
         }
       }
     }

--- a/spec/classes/packages_spec.rb
+++ b/spec/classes/packages_spec.rb
@@ -67,4 +67,36 @@ describe 'kubernetes::packages', :type => :class do
     it { should contain_package('kubeadm').with_ensure('1.10.2')}
     
   end
+
+  context 'with operatingsystem => Debian and container_runtime => docker' do
+    let(:facts) do
+        {
+          :kernel           => 'Linux',
+          :osfamily         => 'Debian',
+          :operatingsystem  => 'Debian',
+          :os               => {
+            :name    => 'Debian',
+            :release => {
+              :major => '9',
+            },
+          },
+        }
+    end
+    let(:params) do
+        {
+        'container_runtime' => 'docker',
+        'kubernetes_version' => '1.10.2',
+        'docker_version' => '17.03.0~ce-0~debian-stretch',
+        'etcd_version' => '3.1.12',
+        'containerd_version' => '1.1.0',
+        'controller' => true,        
+        }
+    end
+    
+    it { should contain_package('docker-engine').with_ensure('17.03.0~ce-0~debian-stretch')}
+    it { should contain_package('kubelet').with_ensure('1.10.2')}
+    it { should contain_package('kubectl').with_ensure('1.10.2')}
+    it { should contain_package('kubeadm').with_ensure('1.10.2')}
+
+  end
 end

--- a/spec/classes/repos_spec.rb
+++ b/spec/classes/repos_spec.rb
@@ -1,7 +1,39 @@
 require 'spec_helper'
 describe 'kubernetes::repos', :type => :class do
 
-  
+  context 'with osfamily => Debian' do
+    let(:facts) do
+      {
+        :operatingsystem => 'Debian',
+        :osfamily => 'Debian',
+        :os               => {
+          :name    => 'Debian',
+          :release => {
+            :major=> '9',
+          },
+        },
+      }
+    end
+
+    let(:params) { { 'container_runtime' => 'docker' } }
+
+    it { should contain_apt__source('kubernetes').with(
+      :ensure   => 'present',
+      :location => 'http://apt.kubernetes.io',
+      :repos    => 'main',
+      :release  => 'kubernetes-xenial',
+      :key      => { 'id' => '54A647F9048D5688D7DA2ABE6A030B21BA07F4FB', 'source' => 'https://packages.cloud.google.com/apt/doc/apt-key.gpg' }
+    ) }
+
+    it { should contain_apt__source('docker').with(
+      :ensure   => 'present',
+      :location => 'https://apt.dockerproject.org/repo',
+      :repos    => 'main',
+      :release  => 'debian-stretch',
+      :key      => { 'id' => '58118E89F3A912897C070ADBF76221572C52609D', 'source' => 'https://apt.dockerproject.org/gpg' }
+    ) }
+  end
+
   context 'with osfamily => Ubuntu' do
     let(:facts) do
       {
@@ -50,4 +82,5 @@ describe 'kubernetes::repos', :type => :class do
     it { should contain_yumrepo('docker') }
     it { should contain_yumrepo('kubernetes') }
   end
+
 end


### PR DESCRIPTION
This commit makes sure that the Stretch Docker APT repository is used
instead of the Xenial repository on Debian.